### PR TITLE
Correct case of rf24g.h filename

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=Requires TMRh20's RF24 library.
 category=Communication
 url=https://hobietime.github.io/RF24G/
 architectures=avr
-includes=RF24G.h
+includes=rf24g.h

--- a/rf24g.cpp
+++ b/rf24g.cpp
@@ -2,7 +2,7 @@
 
 
 #include <RF24.h>
-#include "RF24G.h"
+#include "rf24g.h"
 
 
 


### PR DESCRIPTION
Incorrect capitalization of rf24g.h in library's `#include` directive caused compilation to fail on filename case-sensitive operating systems like Linux.

Incorrect capitalization of rf24g.h in the includes field of library.properties caused compilation to fail from the automatically generated `#include` directive added to sketches by the Arduino IDE's **Sketch > Include Library > RF24G** feature.