### PR TITLE
Updates for the examples

### DIFF
--- a/examples/rf24G_receive.cpp
+++ b/examples/rf24G_receive.cpp
@@ -18,7 +18,7 @@ void loop() {
   // declare packet variable
   packet receiver;
   // declare string to place the packet payload in
-  char payload[30];
+  uint16_t payload;
   // check if the radio has any packets in the receive queue
   if (test.available() == true) {
     Serial.println("packet received!");
@@ -32,7 +32,7 @@ void loop() {
     Serial.print("address: ");
     Serial.println(receiver.getAddress());
     // load the payload into the payload string
-    receiver.readPayload(payload, 30); 
+    receiver.readPayload(&payload, sizeof(payload)); 
     // print the payload 
     Serial.print("payload: ");
     Serial.println(payload);

--- a/examples/rf24G_receive/rf24G_receive.ino
+++ b/examples/rf24G_receive/rf24G_receive.ino
@@ -18,7 +18,7 @@ void loop() {
   // declare packet variable
   packet receiver;
   // declare string to place the packet payload in
-  char payload[30];
+  uint16_t payload;
   // check if the radio has any packets in the receive queue
   if (test.available() == true) {
     Serial.println("packet received!");
@@ -32,10 +32,11 @@ void loop() {
     Serial.print("address: ");
     Serial.println(receiver.getAddress());
     // load the payload into the payload string
-    receiver.readPayload(payload, 30); 
+    receiver.readPayload(&payload, sizeof(payload)); 
     // print the payload 
     Serial.print("payload: ");
     Serial.println(payload);
+
     // since the address in the packet object is already
     // set to the address of the receiver, it doesn't need to be changed
     // hence, we can write the packet back to the receiver

--- a/examples/rf24G_send.cpp
+++ b/examples/rf24G_send.cpp
@@ -16,9 +16,9 @@ void setup() {
 
 void loop() {
   // create a random number
-  uint8_t randNumber = random(300);
+  uint16_t randNumber = random(65535);
   // create a variable to store the received number
-  int actual;
+  uint16_t actual;
   // declare the sender packet variable
   packet sender;
   // declare the receiver packet variable
@@ -26,21 +26,24 @@ void loop() {
   // set the destination of the packet to address 1
   sender.setAddress(1);
   // write the payload to the packet
-  sender.addPayload(&randNumber, sizeof(int));
+  sender.addPayload(&randNumber, sizeof(randNumber));
   // print out the original payload
   Serial.print("original number:");
   Serial.println(randNumber);
   // send the packet, if it is successful try to read back the packet
   if (test.write(&sender) == true) {
+    // wait 500 ms then check for a received packet
+    delay(500);
     // wait until a packet is received
-    while (test.available() != true);
-    // copy the packet into the receiver object
-    test.read(&receiver);
-    // copy the payload into the actual value
-    receiver.readPayload(&actual, sizeof(int));
-    // print out the actual value received
-    Serial.print("received number:");
-    Serial.println(actual);
+    if (test.available() == true){
+      // copy the packet into the receiver object
+      test.read(&receiver);
+      // copy the payload into the actual value
+      receiver.readPayload(&actual, sizeof(randNumber));
+      // print out the actual value received
+      Serial.print("received number:");
+      Serial.println(actual);
+    }
     
   }
 

--- a/examples/rf24G_send/rf24G_send.ino
+++ b/examples/rf24G_send/rf24G_send.ino
@@ -10,15 +10,13 @@ void setup() {
   Serial.begin(9600);
   // create the RF24G object with an address of 4, using pins 7 and 8
   test = RF24_G(4, 7, 8);
-
-  
 }
 
 void loop() {
   // create a random number
-  uint8_t randNumber = random(300);
+  uint16_t randNumber = random(65535);
   // create a variable to store the received number
-  int actual;
+  uint16_t actual;
   // declare the sender packet variable
   packet sender;
   // declare the receiver packet variable
@@ -26,23 +24,22 @@ void loop() {
   // set the destination of the packet to address 1
   sender.setAddress(1);
   // write the payload to the packet
-  sender.addPayload(&randNumber, sizeof(int));
+  sender.addPayload(&randNumber, sizeof(randNumber));
   // print out the original payload
   Serial.print("original number:");
   Serial.println(randNumber);
   // send the packet, if it is successful try to read back the packet
   if (test.write(&sender) == true) {
-    // wait until a packet is received
-    while (test.available() != true);
-    // copy the packet into the receiver object
-    test.read(&receiver);
-    // copy the payload into the actual value
-    receiver.readPayload(&actual, sizeof(int));
-    // print out the actual value received
-    Serial.print("received number:");
-    Serial.println(actual);
-    
+    // wait 500 ms then check for a received packet
+    delay(500);
+    if (test.available() == true) {
+      // copy the packet into the receiver object
+      test.read(&receiver);
+      // copy the payload into the actual value
+      receiver.readPayload(&actual, sizeof(randNumber));
+      // print out the actual value received
+      Serial.print("received number:");
+      Serial.println(actual);
+    }
   }
-
 }
-


### PR DESCRIPTION
Hi, in playing around with this library, I found the examples rather confusing, as they send an 8-bit variable, but treat it like an int and displays it in character values. I modified the examples to transmit a 16-bit variable instead.

- uint8 will only hold values from 0-255, change to uint16_t and increase random value to 0-65535
- Use uint16_t for compatibility between 8-bit, 32-bit and 64-bit systems
- Add delay after successful sending to wait for an available packet: Prevents hangups of the sketch if a packet is missed or a device is reconfigured